### PR TITLE
She just sucks

### DIFF
--- a/graybox/common/graybox_version_info.yaml
+++ b/graybox/common/graybox_version_info.yaml
@@ -8,4 +8,4 @@ text_sensor:
     entity_category: "diagnostic"
     update_interval: 600s
     lambda: |-
-      return { "1.5.5" };
+      return { "1.5.6" };

--- a/graybox/common/templates/graybox_project_details.yaml
+++ b/graybox/common/templates/graybox_project_details.yaml
@@ -1,6 +1,6 @@
 # TODO: sync this with the `graybox/common/graybox_version_info.yaml` file
 substitutions:
-  box_version: "1.5.5"
+  box_version: "1.5.6"
 
 esphome:
   project: !include {file: ../default_project.yaml, vars: {box_version: "${box_version}"}}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Version string-only change with no logic or security impact.
> 
> **Overview**
> Bumps the Graybox firmware/project version from **1.5.5** to **1.5.6** in both places the repo expects them to match: the ESPHome diagnostic `graybox_version_info` template string and the `box_version` substitution in `graybox_project_details.yaml` (used for project metadata and dashboard import URLs).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fc5d06e8858ea3463e8706c6955ecb3809823b5f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->